### PR TITLE
Fix tests broken by upcoming Test::More

### DIFF
--- a/t/hide_middleman.t
+++ b/t/hide_middleman.t
@@ -1,10 +1,10 @@
 #!/usr/bin/env perl
+no circular::require -hide => 'base';
+
 use strict;
 use warnings;
 use lib 't/hide_middleman';
 use Test::More;
-
-no circular::require -hide => 'base';
 
 my @warnings;
 

--- a/t/hide_middleman2.t
+++ b/t/hide_middleman2.t
@@ -1,10 +1,11 @@
 #!/usr/bin/env perl
+no circular::require -hide => ['base', 'parent'];
+
 use strict;
 use warnings;
 use lib 't/hide_middleman';
 use Test::More;
 
-no circular::require -hide => ['base', 'parent'];
 
 my @warnings;
 

--- a/t/hide_middleman3.t
+++ b/t/hide_middleman3.t
@@ -1,15 +1,15 @@
 #!/usr/bin/env perl
-use strict;
-use warnings;
-use lib 't/hide_middleman';
-use Test::More;
-
 no circular::require -hide => [
     qw(base Foo Bar main circular::require),
     (grep { /\.pm$/ }
           map { my $m = $_; $m =~ s+/+::+g; $m =~ s/\.pm$//; $m }
               keys %INC),
 ];
+
+use strict;
+use warnings;
+use lib 't/hide_middleman';
+use Test::More;
 
 my @warnings;
 


### PR DESCRIPTION
circular::require needs to be loaded before base/parent/etc. However
Test::More will soon load base. This makes sure circular::require is the
first thing loaded, even before strict/warnings.

This is a quick fix to get the tests passing again. Ideally the code
would check to see what is already loaded, and warn for some obvious
ones like base/parent.

It would also be good if the code detected PERL5OPT and similar that can
throw this off. It really needs to be good about ensuring it is the
first thing loaded.
